### PR TITLE
chore(ci): Disabled cache in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: rust
 rust:
 - nightly
-cache:
-  cargo: true
 install:
 - rustup install stable
 - rustup update


### PR DESCRIPTION
fix #33 .

If cache enabled, failed because of too big cache.
As a temporary measure, I disabled to use it.