### PR TITLE
fix(tail mode): fix default mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono = "0.4.15"
 scopeguard = "1.1.0"
 log = "0.4.13"
 log4rs = "1.0.0"
+backtrace = "0.3.56"
 
 [dev-dependencies]
 rusoto_mock = "0.45.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use log::info;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tui::{
@@ -14,7 +15,10 @@ use tui::{
 use crate::{
     event::LogEventEvent,
     key_event_wrapper::KeyEventWrapper,
-    state::{logevents_state::LogEventsState, search_state::SearchState},
+    state::{
+        logevents_state::LogEventsState,
+        search_state::{SearchMode, SearchState},
+    },
     ui::{event_area::EventArea, help::Help, side_menu::SideMenu, status_bar::StatusBar, Drawable},
     utils::key_maps_stringify,
 };
@@ -353,10 +357,18 @@ where
                                 .send(LogEventEvent::FetchLogEvents(
                                     i.to_string(),
                                     None,
-                                    Some(SearchState::default()),
+                                    Some(SearchState::new(String::default(), SearchMode::Tail)),
                                     true,
                                 ))
                                 .await;
+                            log::info!("A new log group added, sended an event below to LogEventEventHandler thread.\n{:?}",
+                                  LogEventEvent::FetchLogEvents(
+                                      i.to_string(),
+                                      None,
+                                      Some(SearchState::new(String::default(), SearchMode::Tail)),
+                                      true,
+                                  )
+                            );
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use log::info;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tui::{

--- a/src/handler/tail_logevent_event_handler.rs
+++ b/src/handler/tail_logevent_event_handler.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use async_trait::async_trait;
+use log::info;
 use tokio::sync::mpsc;
 
 use super::*;
@@ -41,6 +42,7 @@ impl EventHandler for TailLogEventEventHandler {
         while let Some(event) = self.inst_rx.recv().await {
             match event {
                 TailLogEventEvent::Start(gname, token, conditions, _need_reset) => {
+                    info!("Tail mode start to fetch");
                     if let Some(search_state) = conditions {
                         self.current_search_condition = search_state.clone();
                     }
@@ -50,6 +52,7 @@ impl EventHandler for TailLogEventEventHandler {
                     self.tail_mode = true;
                 }
                 TailLogEventEvent::Stop => {
+                    info!("Tail mode stop fetching");
                     self.tail_mode = false;
                     self.state.lock().unwrap().reset();
                 }


### PR DESCRIPTION
fix #37 .

When add a new log group, search mode set is OneMinute but this is wrong.
I fixed this to set Tail mode as default mode.

In addition, for easier debugging, I added an arugument `--debug`.
If enable `--debug`, all events will be exported to file
`./log/output.log`.