### PR TITLE
fix(handler): fix panic in the input event handler

### DIFF
--- a/src/handler/input_event_handler.rs
+++ b/src/handler/input_event_handler.rs
@@ -45,7 +45,7 @@ impl EventHandler for InputEventHandler {
         let end_for = Duration::from_millis(120);
         loop {
             // KeyEvent handling
-            if event::poll(self.tick_rate - last_tick.elapsed())? {
+            if event::poll(self.tick_rate.saturating_sub(last_tick.elapsed()))? {
                 if let CEvent::Key(key) = event::read()? {
                     self.input_tx.send(Event::Input(key)).await?;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![feature(duration_saturating_ops)]
 
 #[cfg(test)]
 pub mod test_helper;


### PR DESCRIPTION
fix #38 .

Use `saturating_sub()` instead of `-` to subtract Durations.
By this change, panic because of overflow will be fixed.