### PR TITLE
fix(handler): pass the key event `c` to app's `handle_event()`.

### DIFF
--- a/src/handler/main_event_handler.rs
+++ b/src/handler/main_event_handler.rs
@@ -54,6 +54,8 @@ impl EventHandler for MainEventHandler {
                             if let KeyModifiers::CONTROL = event.modifiers {
                                 teardown_terminal(&mut self.terminal)?;
                                 break;
+                            } else {
+                                middle.app.handle_event(event).await;
                             }
                         }
                         _ => {


### PR DESCRIPTION
fix #41 .